### PR TITLE
ノートの編集機能を改善し、状態管理を最適化

### DIFF
--- a/packages/web/src/app/rooms/[roomId]/page.tsx
+++ b/packages/web/src/app/rooms/[roomId]/page.tsx
@@ -114,7 +114,7 @@ export default async function Page({
 					: undefined
 			}
 			memberRoomId={roomGettingResult.data.memberRoomId}
-			note={roomGettingResult.data.note}
+			initialNote={roomGettingResult.data.note}
 		/>
 	);
 }

--- a/packages/web/src/app/rooms/[roomId]/room.tsx
+++ b/packages/web/src/app/rooms/[roomId]/room.tsx
@@ -27,14 +27,14 @@ const cardList = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, -1];
 
 export function Room({
 	roomId,
-	note,
+	initialNote,
 	ownerRoomId,
 	memberRoomId,
 	initialAutoReset,
 	initialAutoOpen,
 }: {
 	roomId: string;
-	note: string;
+	initialNote: string;
 	ownerRoomId?: string;
 	memberRoomId: string;
 	initialAutoReset: boolean;
@@ -49,17 +49,19 @@ export function Room({
 		unselectCard,
 		open,
 		close,
-		refresh,
 		reset,
 		changeAutoReset,
 		changeAutoOpen,
 		autoOpen,
 		autoReset,
+		note,
+		changeNote,
 	} = usePlanningPoker({
 		roomId,
 		ownerRoomId,
 		initialAutoReset,
 		initialAutoOpen,
+		initialNote,
 	});
 	const [isNoteEditing, setIsNoteEditing] = useState(false);
 
@@ -89,10 +91,11 @@ export function Room({
 					<NoteEditionForm
 						note={note}
 						ownerRoomId={ownerRoomId}
-						onSubmit={async () => {
-							await refresh();
+						onSubmit={async (newNote) => {
+							changeNote(newNote);
 							setIsNoteEditing(false);
 						}}
+						key={note}
 					/>
 				) : (
 					<p className="whitespace-pre-wrap break-all">{note || "-"}</p>


### PR DESCRIPTION
- ノートの状態管理を`usePlanningPoker`フックに統合
- `initialNote`パラメータを追加し、初期値を設定
- ノート編集時のリフレッシュ処理を削除
- リアルタイムでのノート更新をサポート